### PR TITLE
dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,13 +86,13 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>20.0</version>
+            <version>19.2</version>
         </dependency>
         <!-- GSON -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <version>2.9.1</version>
             <scope>compile</scope>
         </dependency>
         <!-- YAML -->
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-cypher-dsl</artifactId>
-            <version>2023.0.3</version>
+            <version>2023.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
@@ -184,6 +184,10 @@
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpcore-nio</artifactId>
 				</exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
 			</exclusions>
         </dependency>
 		<dependency>
@@ -207,6 +211,12 @@
 			<groupId>org.opensearch.client</groupId>
 			<artifactId>opensearch-rest-high-level-client</artifactId>
 			<version>2.5.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
         <!-- AWS Java SDK -->
         <dependency>
@@ -242,6 +252,24 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                  <execution>
+                    <id>enforce</id>
+                    <configuration>
+                      <rules>
+                        <dependencyConvergence/>
+                      </rules>
+                    </configuration>
+                    <goals>
+                      <goal>enforce</goal>
+                    </goals>
+                  </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Fixes the dependency conflicts that caused Neo4j to stop working
- Added the Maven enforcer plugin to troubleshoot this issue and help prevent issues like these in the future